### PR TITLE
Rework hdf output

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -327,7 +327,7 @@ class DataFrameWrapper(object):
         ---------------
         column_name : str
         series : panas.Series
-        case: bool, optional, default False
+        cast: bool, optional, default False
         """
         logger.debug('updating column {!r} in table {!r}'.format(
             column_name, self.name))

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1845,12 +1845,19 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1):
         Iteration interval on which to save data to `data_out`. For example,
         2 will save out every 2 iterations, 5 every 5 iterations.
         Default is every iteration.
-        The first and last iterations are always Inc.ded.
+        The results of the first and last iterations are always included.
+        The input (base) tables are also included and prefixed with `base/`,
+        these represent the state of the system before any steps have been
+        executed.
+        The interval is defined relative to the first iteration. For example,
+        a run begining in 2015 with an out_interval of 2, will write out
+        results for 2015, 2017, etc.
 
     """
     iter_vars = iter_vars or [None]
-    iter_counter = 0
+    max_i = len(iter_vars)
 
+    # write out the base (inputs)
     if data_out:
         write_tables(data_out, steps, 'base')
 
@@ -1882,15 +1889,12 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1):
              'with iteration value {!r}: '
              '{:.2f} s').format(i, var, time.time() - t1))
 
-        if data_out and iter_counter == out_interval:
-            write_tables(data_out, steps, var)
-            iter_counter = 0
+        # write out the results for the current iteration
+        if data_out:
+            if (i - 1) % out_interval == 0 or i == max_i:
+                write_tables(data_out, steps, var)
 
-        iter_counter += 1
         clear_cache(scope=_CS_ITER)
-
-    if data_out and iter_counter != 1:
-        write_tables(data_out, steps, 'final')
 
 
 @contextmanager

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1815,7 +1815,7 @@ def get_step_table_names(steps):
     return list(table_names)
 
 
-def write_tables(fname, table_names=None, prefix=None): 
+def write_tables(fname, table_names=None, prefix=None):
     """
     Writes tables to a pandas.HDFStore file.
 
@@ -1825,15 +1825,16 @@ def write_tables(fname, table_names=None, prefix=None):
         File name for HDFStore. Will be opened in append mode and closed
         at the end of this function.
     table_names: list of str, optional, default None
-        List of tables to write. If None, all registered tables will be written.
-    prefix: str 
+        List of tables to write. If None, all registered tables will
+        be written.
+    prefix: str
         If not None, used to prefix the output table names so that
-        multiple iterations can go in the same file. 
+        multiple iterations can go in the same file.
 
     """
     if table_names is None:
         table_names = list_tables()
-    
+
     tables = (get_table(t) for t in table_names)
     key_template = '{}/{{}}'.format(prefix) if prefix is not None else '{}'
 
@@ -1843,7 +1844,8 @@ def write_tables(fname, table_names=None, prefix=None):
         store.close()
 
 
-def run(steps, iter_vars=None, data_out=None, out_interval=1, base_tables=None, run_tables=None):
+def run(steps, iter_vars=None, data_out=None, out_interval=1,
+        base_tables=None, run_tables=None):
     """
     Run steps in series, optionally repeatedly over some sequence.
     The current iteration variable is set as a global injectable

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1841,11 +1841,10 @@ def write_tables(fname, table_names=None, prefix=None):
     with pd.get_store(fname, mode='a') as store:
         for t in tables:
             store[key_template.format(t.name)] = t.to_frame()
-        store.close()
 
 
 def run(steps, iter_vars=None, data_out=None, out_interval=1,
-        base_tables=None, run_tables=None):
+        out_base_tables=None, out_run_tables=None):
     """
     Run steps in series, optionally repeatedly over some sequence.
     The current iteration variable is set as a global injectable
@@ -1884,18 +1883,18 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
     max_i = len(iter_vars)
 
     # get the tables to write out
-    if base_tables is None or run_tables is None:
+    if out_base_tables is None or out_run_tables is None:
         step_tables = get_step_table_names(steps)
 
-        if base_tables is None:
-            base_tables = step_tables
+        if out_base_tables is None:
+            out_base_tables = step_tables
 
-        if run_tables is None:
-            run_tables = step_tables
+        if out_run_tables is None:
+            out_run_tables = step_tables
 
     # write out the base (inputs)
     if data_out:
-        write_tables(data_out, base_tables, 'base')
+        write_tables(data_out, out_base_tables, 'base')
 
     # run the steps
     for i, var in enumerate(iter_vars, start=1):
@@ -1929,7 +1928,7 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
         # write out the results for the current iteration
         if data_out:
             if (i - 1) % out_interval == 0 or i == max_i:
-                write_tables(data_out, run_tables, var)
+                write_tables(data_out, out_run_tables, var)
 
         clear_cache(scope=_CS_ITER)
 

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -317,19 +317,30 @@ class DataFrameWrapper(object):
 
         raise KeyError('column {!r} not found'.format(column_name))
 
-    def update_col_from_series(self, column_name, series):
+    def update_col_from_series(self, column_name, series, cast=False):
         """
         Update existing values in a column from another series.
-        Index values must match in both column and series.
+        Index values must match in both column and series. Optionally
+        casts data type to match the existing column.
 
         Parameters
         ---------------
         column_name : str
         series : panas.Series
-
+        case: bool, optional, default False
         """
         logger.debug('updating column {!r} in table {!r}'.format(
             column_name, self.name))
+
+        col_dtype = self.local[column_name].dtype
+        if series.dtype != col_dtype:
+            if cast:
+                series = series.astype(col_dtype)
+            else:
+                err_msg = "Data type mismatch, existing:{}, update:{}"
+                err_msg = err_msg.format(col_dtype, series.dtype)
+                raise ValueError(err_msg)
+
         self.local.loc[series.index, column_name] = series
 
     def __len__(self):

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -955,6 +955,32 @@ def test_run_and_write_tables(df, store_name):
                 store['10/table'][year_key(x)], series_year(x))
 
 
+def test_run_and_write_tables_out_tables_provided(df, store_name):
+    table_names = ['table', 'table2', 'table3']
+    for t in table_names:
+        orca.add_table(t, df)
+
+    @orca.step()
+    def step(iter_var, table, table2):
+        return
+
+    orca.run(
+        ['step'],
+        iter_vars=range(1),
+        data_out=store_name,
+        out_base_tables=table_names,
+        out_run_tables=['table'])
+
+    with pd.get_store(store_name, mode='r') as store:
+
+        for t in table_names:
+            assert 'base/{}'.format(t) in store
+
+        assert '0/table' in store
+        assert '0/table2' not in store
+        assert '0/table3' not in store
+
+
 def test_get_raw_table(df):
     orca.add_table('table1', df)
 

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -901,7 +901,7 @@ def test_write_tables(df, store_name):
         pass
 
     step_tables = orca.get_step_table_names(['step'])
-    
+
     orca.write_tables(store_name, step_tables, None)
     with pd.get_store(store_name, mode='r') as store:
         assert 'table' in store
@@ -917,7 +917,7 @@ def test_write_tables(df, store_name):
 def test_write_all_tables(df, store_name):
     orca.add_table('table', df)
     orca.write_tables(store_name)
-    
+
     with pd.get_store(store_name, mode='r') as store:
         for t in orca.list_tables():
             assert t in store

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -356,8 +356,19 @@ def test_update_col(df):
     pdt.assert_series_equal(
         wrapped['b'], pd.Series([7, 8, 9], index=df.index, name='b'))
 
-    wrapped.update_col_from_series('a', pd.Series([]))
+    a_dtype = wrapped['a'].dtype
+
+    # test 1 - cast the data type before the update
+    wrapped.update_col_from_series('a', pd.Series(dtype=a_dtype))
     pdt.assert_series_equal(wrapped['a'], df['a'])
+
+    # test 2 - let the update method do the cast
+    wrapped.update_col_from_series('a', pd.Series(), True)
+    pdt.assert_series_equal(wrapped['a'], df['a'])
+
+    # test 3 - don't cast, should raise an error
+    with pytest.raises(ValueError):
+        wrapped.update_col_from_series('a', pd.Series())
 
     wrapped.update_col_from_series('a', pd.Series([99], index=['y']))
     pdt.assert_series_equal(

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -930,7 +930,7 @@ def test_run_and_write_tables(df, store_name):
         ['step'], iter_vars=range(11), data_out=store_name, out_interval=3)
 
     with pd.get_store(store_name, mode='r') as store:
-        for year in range(3, 11, 3):
+        for year in range(0, 11, 3):
             key = '{}/table'.format(year)
             assert key in store
 
@@ -942,7 +942,7 @@ def test_run_and_write_tables(df, store_name):
 
         for x in range(11):
             pdt.assert_series_equal(
-                store['final/table'][year_key(x)], series_year(x))
+                store['10/table'][year_key(x)], series_year(x))
 
 
 def test_get_raw_table(df):

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -900,17 +900,27 @@ def test_write_tables(df, store_name):
     def step(table):
         pass
 
-    orca.write_tables(store_name, ['step'], None)
-
+    step_tables = orca.get_step_table_names(['step'])
+    
+    orca.write_tables(store_name, step_tables, None)
     with pd.get_store(store_name, mode='r') as store:
         assert 'table' in store
         pdt.assert_frame_equal(store['table'], df)
 
-    orca.write_tables(store_name, ['step'], 1969)
+    orca.write_tables(store_name, step_tables, 1969)
 
     with pd.get_store(store_name, mode='r') as store:
         assert '1969/table' in store
         pdt.assert_frame_equal(store['1969/table'], df)
+
+
+def test_write_all_tables(df, store_name):
+    orca.add_table('table', df)
+    orca.write_tables(store_name)
+    
+    with pd.get_store(store_name, mode='r') as store:
+        for t in orca.list_tables():
+            assert t in store
 
 
 def test_run_and_write_tables(df, store_name):


### PR DESCRIPTION
This addresses #9 and supersedes a previous pull request I made https://github.com/UDST/orca/pull/10:

- Regardless of the output interval, tables will always be output for the base, the 1st iteration's results and the final iteration's results.
  -  The interval is defined relative to the first iteration. For example, a run beginning in 2015, ending in 2020,  with an out_interval of 2, will now write out results for base, 2015, 2017, 2019 and 2020.

  - Base tables are still prefixed with '/base/'.

  - Non-base tables are always prefixed with the iteration value.

  - Previously, the final iteration results were prefixed with '/final/' for cases where the final iteration didn't coincide with the output interval and with the iteration value when it did. This has been changed so that the final iteration tables are always prefixed with the iteration value.

- Optionally, the run method can now be given a set of specific base tables and/or run tables that will be written. If not provided, then the tables will be inferred from those injected into the steps as is done now (this is still the default behavior). I've found this useful for suppressing tables (e.g. OD skims matrix) that are injected into steps every year but that we  don't change and don't want to write because they add a lot of size to the output file. For the base, I typically write out all tables, regardless of what's injected, just to keep everything in a single store.  For example:

```python
orca.run(
    ['my_step'],
    range(2010, 2030),
    data_out=out_file,
    out_interval=5,
    out_base_tables=orca.list_tables(),
    out_run_tables=['a_table']
)
```
- The write_tables method was re-factored so that it no longer take steps as inputs. This allows for outputting tables outside the context of a run:

```python
# just output a couple tables
orca.write_tables(out_h5, ['buildings', 'persons'])

# write out everything that's registered
orca.write_tables(out_h5)

# still allow for step inference
step_tables = orca.get_step_table_names(['my_step'])
orca.write_tables(out_h5, step_tables)
```
The docstrings and tests have been updated to reflect these changes.

I looked through the repo and the only method calling write_tables is the run method. So all tests pass fine. However, if there are calls to orca.write_tables coming from outside orca, then these will now fail. I don't see why this previously would be called outside the context of a run, but if that is the case then I can revert the signature back to the previous version. 

 