### PR TITLE
added iter_step injectable to track current sim step

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1919,7 +1919,8 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
                     i, var))
 
         t1 = time.time()
-        for step_name in steps:
+        for j,step_name in enumerate(steps):
+            add_injectable('iter_step',{j:step_name})
             print('Running step {!r}'.format(step_name))
             with log_start_finish(
                     'run step {!r}'.format(step_name), logger,


### PR DESCRIPTION
Pretty straightforward change here. Adding the _iter_step_ injectable allows us to periodically query the simulation to determine the current model step. We can use that information in conjunction with the _iter_var_ injectable to dynamically track pct. completion and forecast time remaining for simulation runs. 