### PR TITLE
added iter_step injectable to track current sim step

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -408,7 +408,10 @@ Calling :py:func:`~orca.orca.run` with just a list of steps,
 as in the above example, will run through the steps once.
 To run the pipeline over some a sequence, provide those values as a sequence
 to :py:func:`~orca.orca.run` using the ``iter_vars`` argument.
-The variables ``iter_var`` and ``iter_step`` are provided as injectables to Orca functions:
+The variables ``iter_var`` and ``iter_step`` are provided as injectables to Orca functions.
+The ``iter_var`` injectable stores the year of the current simulation iteration, and the 
+``iter_step`` injectable is a tuple that stores the sequence position and name of the current
+simulation step in the iteration:
 
 .. code-block:: python
 

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -408,39 +408,45 @@ Calling :py:func:`~orca.orca.run` with just a list of steps,
 as in the above example, will run through the steps once.
 To run the pipeline over some a sequence, provide those values as a sequence
 to :py:func:`~orca.orca.run` using the ``iter_vars`` argument.
-The variable ``iter_var`` is provided as an injectable to Orca functions:
+The variables ``iter_var`` and ``iter_step`` are provided as injectables to Orca functions:
 
 .. code-block:: python
 
     In [77]: @orca.step()
-       ....: def print_year(iter_var):
+       ....: def print_year(iter_var,iter_step):
        ....:         print '*** the iteration value is {} ***'.format(iter_var)
+       ....:         print '*** the iteration step is {} ***'.format(iter_step.values[0])
        ....:
 
     In [78]: orca.run(['print_year'], iter_vars=range(2010, 2015))
     Running iteration 1 with iteration value 2010
     Running step 'print_year'
     *** the iteration value is 2010 ***
+    *** the iteration step is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 1 with iteration value 2010: 0.00 s
     Running iteration 2 with iteration value 2011
     Running step 'print_year'
     *** the iteration value is 2011 ***
+    *** the iteration step is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 2 with iteration value 2011: 0.00 s
     Running iteration 3 with iteration value 2012
     Running step 'print_year'
     *** the iteration value is 2012 ***
+    *** the iteration step is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 3 with iteration value 2012: 0.00 s
     Running iteration 4 with iteration value 2013
     Running step 'print_year'
     *** the iteration value is 2013 ***
+    *** the iteration step is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 4 with iteration value 2013: 0.00 s
     Running iteration 5 with iteration value 2014
     Running step 'print_year'
     *** the iteration value is 2014 ***
+    *** the iteration step is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 5 with iteration value 2014: 0.00 s
 

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -415,38 +415,38 @@ The variables ``iter_var`` and ``iter_step`` are provided as injectables to Orca
     In [77]: @orca.step()
        ....: def print_year(iter_var,iter_step):
        ....:         print '*** the iteration value is {} ***'.format(iter_var)
-       ....:         print '*** the iteration step is {} ***'.format(iter_step.values[0])
+       ....:         print '*** step {0} is {1} ***'.format(iter_step.keys()[0],iter_step.values()[0])
        ....:
 
     In [78]: orca.run(['print_year'], iter_vars=range(2010, 2015))
     Running iteration 1 with iteration value 2010
     Running step 'print_year'
     *** the iteration value is 2010 ***
-    *** the iteration step is print_year ***
+    *** step 0 is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 1 with iteration value 2010: 0.00 s
     Running iteration 2 with iteration value 2011
     Running step 'print_year'
     *** the iteration value is 2011 ***
-    *** the iteration step is print_year ***
+    *** step 0 is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 2 with iteration value 2011: 0.00 s
     Running iteration 3 with iteration value 2012
     Running step 'print_year'
     *** the iteration value is 2012 ***
-    *** the iteration step is print_year ***
+    *** step 0 is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 3 with iteration value 2012: 0.00 s
     Running iteration 4 with iteration value 2013
     Running step 'print_year'
     *** the iteration value is 2013 ***
-    *** the iteration step is print_year ***
+    *** step 0 is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 4 with iteration value 2013: 0.00 s
     Running iteration 5 with iteration value 2014
     Running step 'print_year'
     *** the iteration value is 2014 ***
-    *** the iteration step is print_year ***
+    *** step 0 is print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 5 with iteration value 2014: 0.00 s
 

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -408,17 +408,18 @@ Calling :py:func:`~orca.orca.run` with just a list of steps,
 as in the above example, will run through the steps once.
 To run the pipeline over some a sequence, provide those values as a sequence
 to :py:func:`~orca.orca.run` using the ``iter_vars`` argument.
-The variables ``iter_var`` and ``iter_step`` are provided as injectables to Orca functions.
-The ``iter_var`` injectable stores the year of the current simulation iteration, and the 
-``iter_step`` injectable is a tuple that stores the sequence position and name of the current
-simulation step in the iteration:
+
+The ``iter_var`` injectable stores the current value from the ``iter_vars`` argument to :py:func:`~orca.orca.run` function. 
+The ``iter_step`` injectable is a ``namedtuple`` with fields named ``step_num`` and ``step_name``, 
+stored in that order. 
+``step_num`` is a zero-based index based on the list of step names passed to the :py:func:`~orca.orca.run` function.
 
 .. code-block:: python
 
     In [77]: @orca.step()
        ....: def print_year(iter_var,iter_step):
        ....:         print '*** the iteration value is {} ***'.format(iter_var)
-       ....:         print '*** step {0} is {1} ***'.format(iter_step[0],iter_step[1])
+       ....:         print '*** step number {0} is named {1} ***'.format(iter_step.step_num, iter_step.step_name)
        ....:
 
     In [78]: orca.run(['print_year'], iter_vars=range(2010, 2015))

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -426,31 +426,31 @@ stored in that order.
     Running iteration 1 with iteration value 2010
     Running step 'print_year'
     *** the iteration value is 2010 ***
-    *** step 0 is print_year ***
+    *** step number 0 is named print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 1 with iteration value 2010: 0.00 s
     Running iteration 2 with iteration value 2011
     Running step 'print_year'
     *** the iteration value is 2011 ***
-    *** step 0 is print_year ***
+    *** step number 0 is named print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 2 with iteration value 2011: 0.00 s
     Running iteration 3 with iteration value 2012
     Running step 'print_year'
     *** the iteration value is 2012 ***
-    *** step 0 is print_year ***
+    *** step number 0 is named print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 3 with iteration value 2012: 0.00 s
     Running iteration 4 with iteration value 2013
     Running step 'print_year'
     *** the iteration value is 2013 ***
-    *** step 0 is print_year ***
+    *** step number 0 is named print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 4 with iteration value 2013: 0.00 s
     Running iteration 5 with iteration value 2014
     Running step 'print_year'
     *** the iteration value is 2014 ***
-    *** step 0 is print_year ***
+    *** step number 0 is named print_year ***
     Time to execute step 'print_year': 0.00 s
     Total time to execute iteration 5 with iteration value 2014: 0.00 s
 

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -415,7 +415,7 @@ The variables ``iter_var`` and ``iter_step`` are provided as injectables to Orca
     In [77]: @orca.step()
        ....: def print_year(iter_var,iter_step):
        ....:         print '*** the iteration value is {} ***'.format(iter_var)
-       ....:         print '*** step {0} is {1} ***'.format(iter_step.keys()[0],iter_step.values()[0])
+       ....:         print '*** step {0} is {1} ***'.format(iter_step[0],iter_step[1])
        ....:
 
     In [78]: orca.run(['print_year'], iter_vars=range(2010, 2015))

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -18,6 +18,7 @@ from zbox import toolz as tz
 
 from . import utils
 from .utils.logutil import log_start_finish
+from collections import namedtuple
 
 warnings.filterwarnings('ignore', category=tables.NaturalNameWarning)
 logger = logging.getLogger(__name__)
@@ -1920,7 +1921,8 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
 
         t1 = time.time()
         for j, step_name in enumerate(steps):
-            add_injectable('iter_step', (j, step_name))
+            iter_step = namedtuple('iter_step', 'step_num,step_name')
+            add_injectable('iter_step', iter_step(j, step_name))
             print('Running step {!r}'.format(step_name))
             with log_start_finish(
                     'run step {!r}'.format(step_name), logger,

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1855,6 +1855,9 @@ def write_tables(fname, table_names=None, prefix=None):
             store[key_template.format(t.name)] = t.to_frame()
 
 
+iter_step = namedtuple('iter_step', 'step_num,step_name')
+
+
 def run(steps, iter_vars=None, data_out=None, out_interval=1,
         out_base_tables=None, out_run_tables=None):
     """
@@ -1921,7 +1924,6 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
 
         t1 = time.time()
         for j, step_name in enumerate(steps):
-            iter_step = namedtuple('iter_step', 'step_num,step_name')
             add_injectable('iter_step', iter_step(j, step_name))
             print('Running step {!r}'.format(step_name))
             with log_start_finish(

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1919,8 +1919,8 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
                     i, var))
 
         t1 = time.time()
-        for j,step_name in enumerate(steps):
-            add_injectable('iter_step',{j:step_name})
+        for j, step_name in enumerate(steps):
+            add_injectable('iter_step', {j: step_name})
             print('Running step {!r}'.format(step_name))
             with log_start_finish(
                     'run step {!r}'.format(step_name), logger,

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1920,7 +1920,7 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
 
         t1 = time.time()
         for j, step_name in enumerate(steps):
-            add_injectable('iter_step', {j: step_name})
+            add_injectable('iter_step', (j, step_name))
             print('Running step {!r}'.format(step_name))
             with log_start_finish(
                     'run step {!r}'.format(step_name), logger,

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1919,7 +1919,8 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
                     i, var))
 
         t1 = time.time()
-        for step_name in steps:
+        for j,step_name in enumerate(steps):
+            add_injectable('iter_step',{j:step_name})
             print('Running step {!r}'.format(step_name))
             with log_start_finish(
                     'run step {!r}'.format(step_name), logger,


### PR DESCRIPTION
Pretty straightforward change here. Adding the <iter_step> injectable allows us to periodically query the simulation to determine the current model step. We can use that information in conjunction with the <iter_var> injectable to dynamically track pct. completion and forecast time remaining for simulation runs. 