### PR TITLE
Update deprecated pandas index diff function

### DIFF
--- a/orca/utils/testing.py
+++ b/orca/utils/testing.py
@@ -66,8 +66,8 @@ def assert_index_equal(left, right):
     """
     assert isinstance(left, pd.Index)
     assert isinstance(right, pd.Index)
-    left_diff = left.diff(right)
-    right_diff = right.diff(left)
+    left_diff = left.difference(right)
+    right_diff = right.difference(left)
     if len(left_diff) > 0 or len(right_diff) > 0:
         raise AssertionError("keys not in left [{0}], keys not in right [{1}]".format(
             left_diff, right_diff))

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
             'server/templates/*']
     },
     install_requires=[
-        'pandas >= 0.13.1',
+        'pandas >= 0.15.0',
         'tables >= 3.1.0',
         'toolz >= 0.7.0',
         'zbox >= 1.2'


### PR DESCRIPTION
Changing index.diff (deprecated in recent pandas versions) to index.difference, and bumping the minimum pandas version in setup.py to .15.  

Travis jobs have indicated this is an issue. This change is analogous to the one made in the following pull request in the `urbansim` repo:
https://github.com/UDST/urbansim/pull/179

