### PR TITLE
Extend variable expressions for tables

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -943,8 +943,25 @@ def _collect_variables(names, expressions=None):
         if '.' in expression:
             # Registered variable expression refers to column.
             table_name, column_name = expression.split('.')
-            table = get_table(table_name)
-            variables[label] = table.get_column(column_name)
+
+            if column_name == '*':
+                # return a table view with all columns
+                variables[label] = get_table_view(table_name)
+            elif column_name == 'local':
+                # return a table view with just the local columns
+                variables[label] = get_table_view(table_name, 'local')
+            else:
+                # return a single column
+                table = get_table(table_name)
+                variables[label] = table.get_column(column_name)
+
+        elif '[' in expression and expression.endswith(']'):
+            # evaluate a subset of columns
+            table_name, cols = expression[:-1].split('[')
+            cols = cols.split(',')
+            cols = map(str.strip, cols)
+            variables[label] = get_table_view(table_name, cols)
+
         else:
             thing = all_variables[expression]
             if isinstance(thing, (_InjectableFuncWrapper, TableFuncWrapper)):

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1069,6 +1069,45 @@ def get_table(table_name):
     return table
 
 
+def get_table_view(table_name, columns=None):
+    """
+    Get a view of the registered table.
+
+    Parameters
+    ----------
+    table_name: str
+        Name of the registered orca table.
+    columns: str or list, optional, default None
+        Subset of columns to collect.
+        Use the 'local' keyword to fetch all local columns.
+
+    Returns
+    -------
+    pandas.DataFrame with extensions:
+        - wrapper: returns the orca table for the view.
+        - update_col: updates or adds a column to the wrapper.
+        - update_col_from_series: updates a column in the wrapper from a series.
+
+    """
+    wrapper = get_table(table_name)
+
+    # handle local keyword
+    if columns == 'local':
+        columns = wrapper.local_columns
+    elif isinstance(columns, list) and 'local' in columns:
+        columns = wrapper.local_columns + columns
+        columns.remove('local')
+
+    # evaluate the table
+    df = wrapper.to_frame(columns)
+
+    # add extension methods and return
+    df.wrapper = wrapper
+    df.update_col = wrapper.update_col
+    df.update_col_from_series = wrapper.update_col_from_series
+    return df
+
+
 def table_type(table_name):
     """
     Returns the type of a registered table.


### PR DESCRIPTION
This PR extends the existing [variable expressions framework](https://udst.github.io/orca/core.html#variable-expressions), to allow table to_frame() calls to be evaluated at the time of injection. This is intended to partially address https://github.com/UDST/orca/issues/15, with the primary goal of making it easier to specify column-level dependencies so that we can eventually build dependency graphs with more dynamic caches. This is intended to provide a new potential workflow, and shouldn't impact existing workflows and configurations.

Typically, when using tables, we do something like this:

````python
@orca.step
def my_step(households, buildings):
  # get data frome the wrapper
  hh_df = households.to_frame([‘col1’, ‘col2’])
  bldgs_df = buildings.to_frame()
  
  # some logic using the fetched data
  new_col = hh_df['col2'] / 2

  # update the underlying data
  households.update_col('col2', new_col)
````

This is nice because it's super flexible, but it's really difficult to capture column-level dependencies, since at the time injection, only the wrapper is collected and any column could be used later within the function. Using the new expressions, we essentially move all to_frame calls into the arguments so we know exactly which columns are being used:

```python
@orca.step
def my_step(hh_df='households[col1, col2]', bldgs_df='buildings.*'):
  # some logic ...
  new_col = hh_df['col2'] / 2

  # update the underlying data
  hh_df.update_col('col2', new_col)
```
Note that what is injected here is a Pandas DataFrame, not an orca TableWrapper. However, the data frame is appended with the following, so it can update the underlying data:

- _.wrapper_: returns a reference to the orca table wrapper
- _.update_col_: calls TableWrapper.update_col
- _.update_col_from_series_: calls TableWrapper.update_col_from_series

The following expressions are supported for table to_frame() calls:

- fetch all columns: `hh='households.*'`
- fetch only local columns: `hh='households.local'`
- fetch specific columns: `hh='households[col1, col2]'`
- fetch all local columns and specific extra columns: `hh='households[local, col2]'`

This can also be used outside of a function argument as shorthand for to_frame calls:

```python
hh_view = orca.get_table_view('households', ['local', 'col1'])
new_col = hh_view['col1'] + hh_view['col2']
hh_view.update_col('col3', new_col)
```

See the tests for worked examples:
- https://github.com/AZMAG/orca/blob/variable_expressions/orca/tests/test_orca.py#L379
- https://github.com/AZMAG/orca/blob/variable_expressions/orca/tests/test_orca.py#L1304

Thoughts?
