### PR TITLE
Allow the "run" function to store local columns only

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1914,7 +1914,7 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
         or both, local and computed columns (False).
     out_run_local: boolean, optional, default False
         For tables in out_run_tables, whether to store only local columns (True)
-        or both, local and computed columns (False).        
+        or both, local and computed columns (False).
     """
     iter_vars = iter_vars or [None]
     max_i = len(iter_vars)

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -1872,7 +1872,7 @@ iter_step = namedtuple('iter_step', 'step_num,step_name')
 
 def run(steps, iter_vars=None, data_out=None, out_interval=1,
         out_base_tables=None, out_run_tables=None, compress=False,
-        out_base_local=True, out_run_local=False):
+        out_base_local=True, out_run_local=True):
     """
     Run steps in series, optionally repeatedly over some sequence.
     The current iteration variable is set as a global injectable
@@ -1912,7 +1912,7 @@ def run(steps, iter_vars=None, data_out=None, out_interval=1,
     out_base_local: boolean, optional, default True
         For tables in out_base_tables, whether to store only local columns (True)
         or both, local and computed columns (False).
-    out_run_local: boolean, optional, default False
+    out_run_local: boolean, optional, default True
         For tables in out_run_tables, whether to store only local columns (True)
         or both, local and computed columns (False).
     """


### PR DESCRIPTION
This addresses the issue discussed [here (by @janowicz on Feb 21st)](http://discussion.urbansim.com/t/using-injectables-in-orca-columns/50/4). Currently the run function writes out all variables regardless if they are used or not which can result in huge files. This happens for both, the base year data as well as every orca iteration, because the write_tables() function simply calls to_frame().

This PR adds two boolean arguments to the run function (out_base_local and out_run_local). If True, only local columns are stored for out_base_tables and out_run_tables, respectively. The write_tables function gets a boolean argument called "local". (Note that after PR #22 of @bridwell is accepted, the write_tables function can pass an expression to to_frame() for obtaining local columns only.)

In our case this change reduces the output file size more than 4 times.

Please feel free to rename the new arguments if needed.
 