### PR TITLE
use inspect.getfullargsec if available in order to allow type hints…

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -4,7 +4,10 @@
 
 from __future__ import print_function
 
-import inspect
+try:
+    from inspect import getfullargspec as getargspec
+except ImportError:
+    from inspect import getargspec
 import logging
 import time
 import warnings
@@ -394,7 +397,7 @@ class TableFuncWrapper(object):
             copy_col=True):
         self.name = name
         self._func = func
-        self._argspec = inspect.getargspec(func)
+        self._argspec = getargspec(func)
         self.cache = cache
         self.cache_scope = cache_scope
         self.copy_col = copy_col
@@ -609,7 +612,7 @@ class _ColumnFuncWrapper(object):
         self.table_name = table_name
         self.name = column_name
         self._func = func
-        self._argspec = inspect.getargspec(func)
+        self._argspec = getargspec(func)
         self.cache = cache
         self.cache_scope = cache_scope
 
@@ -731,7 +734,7 @@ class _InjectableFuncWrapper(object):
     def __init__(self, name, func, cache=False, cache_scope=_CS_FOREVER):
         self.name = name
         self._func = func
-        self._argspec = inspect.getargspec(func)
+        self._argspec = getargspec(func)
         self.cache = cache
         self.cache_scope = cache_scope
 
@@ -783,7 +786,7 @@ class _StepFuncWrapper(object):
     def __init__(self, step_name, func):
         self.name = step_name
         self._func = func
-        self._argspec = inspect.getargspec(func)
+        self._argspec = getargspec(func)
 
     def __call__(self):
         with log_start_finish('calling step {!r}'.format(self.name), logger):


### PR DESCRIPTION
…in orca functions

I would like to use PEP 484 -Style Type Hints in orca-functions.
orca uses inspect.getargspec so far, which does not allow annotations in function signatures.
However, inspect.getfullargspec, which is available in python 3, accepts the annotations.
I propose to use getfullargspec if it is available in orca.py (with a fallback to getargspec in python 2, which might raise an ImportError).
Both functions return an argspec-object with the attributes .args and .defaults.

Best Regards, Max