### PR TITLE
Fix bug in server test

### DIFF
--- a/orca/server/tests/test_server.py
+++ b/orca/server/tests/test_server.py
@@ -367,7 +367,7 @@ def test_table_groupbyagg_by_size(tapp):
 
     pdt.assert_series_equal(
         test,
-        pd.Series([2, 2, 1], index=[100, 200, 300]))
+        pd.Series([2, 2, 1], index=[100, 200, 300], name='a'))
 
 
 def test_table_groupbyagg_level_mean(tapp):


### PR DESCRIPTION
[This change](https://github.com/pandas-dev/pandas/issues/5677) to Pandas groupby in the latest Pandas release broke a test. Quick fix, not urgent to release, should go in with next minor version.