### PR TITLE
Allow to_frame() to take a string outside of a sequence

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -198,8 +198,9 @@ class DataFrameWrapper(object):
 
         Parameters
         ----------
-        columns : sequence, optional
-            Sequence of the column names desired in the DataFrame.
+        columns : sequence or string, optional
+            Sequence of the column names desired in the DataFrame. A string
+            can also be passed if only one column is desired.
             If None all columns are returned, including registered columns.
 
         Returns
@@ -210,6 +211,7 @@ class DataFrameWrapper(object):
         extra_cols = _columns_for_table(self.name)
 
         if columns:
+            columns = [columns] if isinstance(columns, str) else columns
             columns = set(columns)
             set_extra_cols = set(extra_cols)
             local_cols = set(self.local.columns) & columns - set_extra_cols

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -58,6 +58,7 @@ def test_tables(df):
     assert len(table) is 0
     pdt.assert_frame_equal(table.to_frame(), df / 2)
     pdt.assert_frame_equal(table.to_frame(columns=['a']), df[['a']] / 2)
+    pdt.assert_frame_equal(table.to_frame(columns='a'), df[['a']] / 2)
     pdt.assert_index_equal(table.index, df.index)
     pdt.assert_series_equal(table.get_column('a'), df.a / 2)
     pdt.assert_series_equal(table.a, df.a / 2)


### PR DESCRIPTION
Fixes #27.

@fscottfoti would like to see if you have any thoughts. @Eh2406 you might also be interested since this involves your code in the to_frame() method. Please see #27 for a better description.