### PR TITLE
Update to_frame() behavior for columns=[]

### DIFF
--- a/orca/orca.py
+++ b/orca/orca.py
@@ -210,7 +210,7 @@ class DataFrameWrapper(object):
         """
         extra_cols = _columns_for_table(self.name)
 
-        if columns:
+        if columns is not None:
             columns = [columns] if isinstance(columns, str) else columns
             columns = set(columns)
             set_extra_cols = set(extra_cols)

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -57,6 +57,7 @@ def test_tables(df):
     assert table.columns == []
     assert len(table) is 0
     pdt.assert_frame_equal(table.to_frame(), df / 2)
+    pdt.assert_frame_equal(table.to_frame([]), df[[]])
     pdt.assert_frame_equal(table.to_frame(columns=['a']), df[['a']] / 2)
     pdt.assert_frame_equal(table.to_frame(columns='a'), df[['a']] / 2)
     pdt.assert_index_equal(table.index, df.index)


### PR DESCRIPTION
Addresses #30. This simple change enables the behavior we're looking for: now upon passing an empty list to the `columns` parameter of `to_frame()`, a DataFrame with the appropriate index, but no columns, should be returned. This equivalent to calling `df[[]]`.

@Eh2406 you might want to take a look.