### PR TITLE
Update required version of toolz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     install_requires=[
         'pandas >= 0.15.0',
         'tables >= 3.1.0',
-        'toolz >= 0.7.0'
+        'toolz >= 0.8.1'
     ],
     extras_require={
         'server': ['flask >= 0.10', 'pygments >= 2.0', 'six >= 1.9.0']


### PR DESCRIPTION
With the v1.5.0 release, we removed `zbox` as a dependency, since `toolz` now provides native functionality to automatically use `cytoolz` if installed (under the `tlz` package).

However, this was only introduced in `toolz` v0.8.1 and I forgot to bump the required version number. 