### PR TITLE
Fix groupby unit test

### DIFF
--- a/orca/server/tests/test_server.py
+++ b/orca/server/tests/test_server.py
@@ -134,7 +134,7 @@ def test_table_describe(tapp):
     data = rv.data.decode('utf-8')
 
     assert data == \
-        orca.get_table('dfa').to_frame().describe().to_json(orient='split')
+           orca.get_table('dfa').to_frame().describe().to_json(orient='split')
 
 
 def test_table_definition_frame(tapp):
@@ -222,7 +222,7 @@ def test_column_describe(tapp):
     data = rv.data.decode('utf-8')
 
     assert data == \
-        orca.get_table('dfa').extra_acol.describe().to_json(orient='split')
+           orca.get_table('dfa').extra_acol.describe().to_json(orient='split')
 
 
 def test_column_csv(tapp, dfa):
@@ -367,7 +367,8 @@ def test_table_groupbyagg_by_size(tapp):
 
     pdt.assert_series_equal(
         test,
-        pd.Series([2, 2, 1], index=[100, 200, 300], name='a'))
+        pd.Series([2, 2, 1], index=[100, 200, 300]),
+        check_names=False)
 
 
 def test_table_groupbyagg_level_mean(tapp):

--- a/orca/server/tests/test_server.py
+++ b/orca/server/tests/test_server.py
@@ -133,8 +133,10 @@ def test_table_describe(tapp):
 
     data = rv.data.decode('utf-8')
 
-    assert data == \
-           orca.get_table('dfa').to_frame().describe().to_json(orient='split')
+    assert data == (orca.get_table('dfa')
+                        .to_frame()
+                        .describe()
+                        .to_json(orient='split'))
 
 
 def test_table_definition_frame(tapp):
@@ -221,8 +223,9 @@ def test_column_describe(tapp):
 
     data = rv.data.decode('utf-8')
 
-    assert data == \
-           orca.get_table('dfa').extra_acol.describe().to_json(orient='split')
+    assert data == (orca.get_table('dfa')
+                        .extra_acol.describe()
+                        .to_json(orient='split'))
 
 
 def test_column_csv(tapp, dfa):


### PR DESCRIPTION
In response to #34. The pandas v0.20.1 release in May caused a test involving `groupby` to fail, and I made a quick fix in #28. It turns out that fix made tests pass in versions of Pandas >= 0.20.1, but fail in versions < 0.20.1.

This PR makes the failing test work with versions of Pandas before and after 0.20.1.