### PR TITLE
[v1.5.4.dev0] Compatibility updates

### DIFF
--- a/orca/__init__.py
+++ b/orca/__init__.py
@@ -4,4 +4,4 @@
 
 from .orca import *
 
-version = __version__ = '1.5.3'
+version = __version__ = '1.5.4.dev0'

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -12,9 +12,13 @@ import logging
 import time
 import warnings
 from collections import namedtuple
-from collections.abc import Callable
+try:
+    from collections.abc import Callable
+except ImportError:  # Python 2.7
+    from collections import Callable
 from contextlib import contextmanager
 from functools import wraps
+
 
 import pandas as pd
 import tables

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -16,11 +16,6 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
 
-try:
-    from tlz.compatibility import zip as zip  # for Python 2.7
-except ImportError:
-    pass
-
 import pandas as pd
 import tables
 import tlz as tz

--- a/orca/orca.py
+++ b/orca/orca.py
@@ -11,9 +11,15 @@ except ImportError:
 import logging
 import time
 import warnings
-from collections import Callable, namedtuple
+from collections import namedtuple
+from collections.abc import Callable
 from contextlib import contextmanager
 from functools import wraps
+
+try:
+    from tlz.compatibility import zip as zip  # for Python 2.7
+except ImportError:
+    pass
 
 import pandas as pd
 import tables
@@ -21,7 +27,6 @@ import tlz as tz
 
 from . import utils
 from .utils.logutil import log_start_finish
-from collections import namedtuple
 
 warnings.filterwarnings('ignore', category=tables.NaturalNameWarning)
 logger = logging.getLogger(__name__)
@@ -937,8 +942,8 @@ def _collect_variables(names, expressions=None):
         expressions = []
     offset = len(names) - len(expressions)
     labels_map = dict(tz.concatv(
-        tz.compatibility.zip(names[:offset], names[:offset]),
-        tz.compatibility.zip(names[offset:], expressions)))
+        zip(names[:offset], names[:offset]),
+        zip(names[offset:], expressions)))
 
     all_variables = tz.merge(_INJECTABLES, _TABLES)
     variables = {}

--- a/orca/server/server.py
+++ b/orca/server/server.py
@@ -336,7 +336,7 @@ def column_csv(table_name, col_name):
     Return a column as CSV using Pandas' default CSV output.
 
     """
-    csv = orca.get_table(table_name).get_column(col_name).to_csv(path=None)
+    csv = orca.get_table(table_name).get_column(col_name).to_csv(path_or_buf=None)
     return csv, 200, {'Content-Type': 'text/csv'}
 
 

--- a/orca/server/tests/test_server.py
+++ b/orca/server/tests/test_server.py
@@ -1,8 +1,9 @@
 import json
 
 import orca
+import numpy as np
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from .. import server
@@ -233,7 +234,7 @@ def test_column_csv(tapp, dfa):
     assert rv.status_code == 200
 
     data = rv.data.decode('utf-8')
-    assert data == dfa.a.to_csv(path=None)
+    assert data == dfa.a.to_csv(path_or_buf=None)
 
 
 def test_no_column_404(tapp):
@@ -420,5 +421,5 @@ def test_table_groupbyagg_level_std(tapp):
     pdt.assert_series_equal(
         test,
         pd.Series(
-            [pd.np.nan, pd.Series([80, 90]).std()],
+            [np.nan, pd.Series([80, 90]).std()],
             index=['a', 'b'], name='b'))

--- a/orca/tests/test_orca.py
+++ b/orca/tests/test_orca.py
@@ -6,8 +6,8 @@ import os
 import tempfile
 
 import pandas as pd
+import pandas.testing as pdt
 import pytest
-from pandas.util import testing as pdt
 
 from .. import orca
 from ..utils.testing import assert_frames_equal

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='orca',
-    version='1.5.3',
+    version='1.5.4.dev0',
     description='A pipeline orchestration tool with Pandas support',
     long_description=long_description,
     author='UrbanSim Inc.',


### PR DESCRIPTION
This PR provides compatibility updates to support current and future versions of Python, Pandas, and PyToolz.

1. Switches abstract base class imports from `collections` to `collections.abc` for Python 3 (deprecated in v3.3, stops working in Python 3.8)

2. `pandas.util.testing` –> `pandas.testing` (per a deprecation warning)

3. `pd.Series().to_csv(path=..)` –> `pd.Series().to_csv(path_or_buf=..)` (deprecated in v0.24, stops working in Pandas 1.0 i think)

4. `pd.np.nan` –> `np.nan` (Pandas used to allow this if you didn't want to import numpy, I guess, but it stopped working)

5. Dropped use of a cross-Python-compatibility version of the `zip()` function from PyToolz, in favor of native Python `zip()`. The functionality for this changed in PyToolz v0.11 in a way that breaks our code. See issue #50, which this resolves.

### Testing

Unit tests are passing in Python 2.7, 3.5, 3.6, 3.7, 3.8, and 3.9